### PR TITLE
Set zip_safe=False to allow django migrations to function.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,4 +30,5 @@ setup(
         'dbstorage.migrations',
     ],
     include_package_data=True,
+    zip_safe=False
 )


### PR DESCRIPTION
Migrations cannot be performed when installed as a single .egg file.

Adding zip_safe=False to its setup.py and re-packaging and re-installing solves the problem.